### PR TITLE
Fix typo in call to AssetsService in SecureAssetDownloadService

### DIFF
--- a/secureassetdownload/services/SecureAssetDownloadService.php
+++ b/secureassetdownload/services/SecureAssetDownloadService.php
@@ -44,7 +44,7 @@ class SecureAssetDownloadService extends BaseApplicationComponent
   {
     if (isset($options['id'])) {
       if (!$this->_asset or $this->_asset->id != $options['id'] or !$this->_asset instanceof AssetFileModel) {
-        $this->_asset = craft()->asset->getFileById($options['id']);
+        $this->_asset = craft()->assets->getFileById($options['id']);
 
         if (!$this->_asset) {
           throw new Exception(Craft::t("Unable to find asset"));


### PR DESCRIPTION
Ran into a tiny typo when using this bad boy:

`craft()->assets->getFileById` not  `craft()->asset-> getFileById`