### PR TITLE
Preparation for onetime downloads and expiring downloads

### DIFF
--- a/secureassetdownload/controllers/SecureAssetDownloadController.php
+++ b/secureassetdownload/controllers/SecureAssetDownloadController.php
@@ -8,6 +8,10 @@ class SecureAssetDownloadController extends BaseController
 		if ($variables and $variables["crypt"]) {
 			$options = craft()->secureAssetDownload->decodeUrlParam($variables["crypt"]);
 
+			if (gettype($options)!='array') {
+				throw new HttpException('404', 'Invalid asset URL');
+			}
+
 			if (!craft()->secureAssetDownload->isDownloadAllowed($options)) {
 				throw new Exception(Craft::t("You do not have permission to download this file"));
 			}

--- a/secureassetdownload/services/SecureAssetDownloadService.php
+++ b/secureassetdownload/services/SecureAssetDownloadService.php
@@ -31,6 +31,12 @@ class SecureAssetDownloadService extends BaseApplicationComponent
           $options['userGroupId'] = $criteria['userGroupId'];
         }
 
+        $options['onetime'] = (isset($criteria['onetime']) ? $criteria['onetime'] : false);
+        if ($options['onetime']) {
+            $options['duration'] = (isset($criteria['duration']) ? $criteria['duration'] : 60);
+            $options['time'] = time();
+        }
+
         $urlParam = $this->encodeUrlParam($options);
 
         return UrlHelper::getSiteUrl('secureAssetDownload/' . $urlParam);
@@ -97,6 +103,17 @@ class SecureAssetDownloadService extends BaseApplicationComponent
 
       if (!$this->_asset) {
         return false;
+      }
+
+      if ($options['onetime']) {
+          $time = isset($options['duration']) ? $options['duration'] : $key = craft()->plugins->getPlugin("secureAssetDownload")->getSettings()->timeKey;
+          if ( (time() - $options['time']) >= $time ) {
+              throw new Exception(Craft::t("Link Expired"));
+              return false;
+          }
+        //   throw new Exception(Craft::t( time() - $options['time'] . "   " . $time));
+          $options['time'] -= $time;
+        //   throw new Exception(Craft::t("\$options['onetime']: " . $options['onetime'] . " | \$options['time']: " . $options['time'] . " | \$time: " . $time . " | time: " . time() ));
       }
 
       if (!craft()->userSession->isLoggedIn()) {

--- a/secureassetdownload/templates/_settings.twig
+++ b/secureassetdownload/templates/_settings.twig
@@ -11,3 +11,14 @@
   required: true,
   errors: ''
 }) }}
+{{ forms.textField({
+  label: "Time"|t,
+  id: 'timeKey',
+  name: 'timeKey',
+  instructions: "Global Time for one-time-downloads"|t,
+  value: settings.timeKey,
+  autofocus: true,
+  first: true,
+  required: true,
+  errors: ''
+}) }}


### PR DESCRIPTION
Expiring downloads working. Onetime downloads don't because of SecureAssetDownloadService.php:115.
URL is only valid for the set time. A new URL get generated every time the page gets loaded.